### PR TITLE
test(e2e): add Playwright UI flows for navigation and info modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:typecheck": "tsc --noEmit",
     "test:e2e:smoke:playwright": "node scripts/e2e-smoke.mjs",
     "test:e2e:smoke:http": "node scripts/e2e-http-smoke.mjs",
-    "test:e2e:smoke": "node scripts/e2e-smoke-runner.mjs"
+    "test:e2e:smoke": "node scripts/e2e-smoke-runner.mjs",
+    "test:e2e:ui": "node scripts/e2e-ui-runner.mjs"
   },
   "dependencies": {
     "@emotion/react": "^11.10.5",

--- a/scripts/e2e-ui-runner.mjs
+++ b/scripts/e2e-ui-runner.mjs
@@ -1,0 +1,28 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+function run(cmd, args, env = process.env) {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, {
+      stdio: 'inherit',
+      env,
+    });
+    child.on('close', (code) => resolve(code ?? 1));
+  });
+}
+
+const env = { ...process.env };
+const localBrowsersPath = path.resolve(process.cwd(), '.playwright-browsers');
+
+if (!env.PLAYWRIGHT_BROWSERS_PATH && fs.existsSync(localBrowsersPath)) {
+  env.PLAYWRIGHT_BROWSERS_PATH = localBrowsersPath;
+}
+
+const code = await run('node', ['scripts/e2e-ui.mjs'], env);
+if (code !== 0) {
+  console.warn(
+    'UI E2E failed. Ensure browser binaries are installed: yarn playwright install chromium',
+  );
+}
+process.exit(code);

--- a/scripts/e2e-ui.mjs
+++ b/scripts/e2e-ui.mjs
@@ -1,0 +1,87 @@
+import { chromium } from 'playwright';
+
+const baseUrl = process.env.E2E_BASE_URL || 'http://localhost:3000';
+
+async function expectVisible(page, selector, message) {
+  const count = await page.locator(selector).count();
+  if (count === 0) {
+    throw new Error(message);
+  }
+}
+
+async function expectHeading(page, name, message) {
+  const heading = page.getByRole('heading', { name });
+  await heading.waitFor({ state: 'visible', timeout: 10000 });
+  const count = await heading.count();
+  if (count === 0) {
+    throw new Error(message);
+  }
+}
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage();
+
+try {
+  await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 20000 });
+
+  // Public home
+  await expectVisible(page, 'h1:text("GearLife")', 'Home heading not found.');
+  await expectVisible(
+    page,
+    '[aria-label="Abrir informações"]',
+    'Info button not found on home header.',
+  );
+
+  // Open and close info modal with real user interactions
+  await page.getByLabel('Abrir informações').click();
+  await expectVisible(
+    page,
+    'text=Como usar o aplicativo para monitorar equipamentos',
+    'Info modal content did not open.',
+  );
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(150);
+  const stillVisible = await page
+    .locator('text=Como usar o aplicativo para monitorar equipamentos')
+    .count();
+  if (stillVisible !== 0) {
+    throw new Error('Info modal did not close after pressing Escape.');
+  }
+
+  // Navigate through public pages using clickable links
+  await page.getByRole('link', { name: 'Como funciona' }).first().click();
+  await page.waitForURL('**/como-funciona', { timeout: 10000 });
+  await expectHeading(
+    page,
+    /Como funciona o GearLife/i,
+    'Como funciona page heading not found.',
+  );
+
+  await page.getByRole('link', { name: 'FAQ' }).first().click();
+  await page.waitForURL('**/faq', { timeout: 10000 });
+  await expectHeading(
+    page,
+    /Perguntas frequentes/i,
+    'FAQ page heading not found.',
+  );
+
+  await page.getByRole('link', { name: 'Contato' }).first().click();
+  await page.waitForURL('**/contato', { timeout: 10000 });
+  await expectHeading(page, /Contato/i, 'Contato page heading not found.');
+  await expectVisible(
+    page,
+    'a[href^="mailto:"]',
+    'Contact mailto link not found.',
+  );
+
+  // Return to home via public nav
+  await page.getByRole('link', { name: 'Início' }).first().click();
+  await page.waitForFunction(() => window.location.pathname === '/', {
+    timeout: 10000,
+  });
+  await expectHeading(page, /GearLife/i, 'Failed to return to home.');
+
+  console.log('E2E UI passed.');
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
## Resumo
Este PR adiciona testes E2E de interface com Playwright e consolida o fluxo de quality gate no repositório.

## O que foi adicionado
- Novo fluxo E2E de UI com interações reais:
  - abrir modal de informações
  - fechar modal com `Escape`
  - navegar entre páginas públicas (`Como funciona`, `FAQ`, `Contato`, `Início`)
  - validar heading e link de contato (`mailto`)
- Novo runner para E2E UI com suporte ao cache local de browsers do Playwright.
- Novo script:
  - `yarn test:e2e:ui`

## Arquivos principais
- `scripts/e2e-ui.mjs`
- `scripts/e2e-ui-runner.mjs`
- `package.json`

## Como validar localmente
```bash
yarn test:e2e:smoke
yarn test:e2e:ui
