### PR TITLE
chore: add local dev harness

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,66 +1,125 @@
-# Instruções do Copilot / Agente AI para strava-next
+# Regras e Diretrizes do Agente AI para **GearLife** (strava-next)
 
-Propósito: fornecer ao agente AI o contexto mínimo e acionável para ser produtivo neste repositório.
+Este documento define regras de codificação, padrões de segurança e receitas de desenvolvimento ("Skills") para guiar qualquer agente de Inteligência Artificial ou desenvolvedor na manutenção e evolução deste repositório com consistência e segurança absoluta.
 
-- Tipo de projeto: Next.js + TypeScript — aplicação monorepo com rotas API (server-side) que integra com a API do Strava.
-- Runtime: Node.js (>=16). Inicie localmente com `npm run dev` ou `yarn dev` (ver `Readme.md`).
+---
 
-Visão geral (o que revisar primeiro)
+## 🎯 1. Regras de Arquitetura e Codificação (Rules)
 
-- Frontend: `src/pages/*` e `src/components/*` — UI React/Next padrão.
-- API server-side: `src/pages/api/*` contém fluxos de OAuth (`authorize.tsx`), persistência de tokens (`save-tokens.ts`) e webhook (`webhook.ts`). Considere esses arquivos como a lógica servidor "canônica".
-- Camada de serviços: `src/services/*` concentra integrações e lógica de negócio. Arquivos importantes:
-  - `src/services/strava-auth.ts` — leitura/gravação de tokens, refresh de token (usa chaves de Redis definidas em `config`).
-  - `src/services/api.ts` — instâncias axios pré-configuradas (`apiStravaOauthToken`, `apiStravaAuth`, `apiRemoteStorage`) com header `X-Request-ID` para tracing.
-  - `src/services/redis.ts` — inicializa Upstash Redis via `Redis.fromEnv()`; uso restrito ao servidor.
-  - `src/services/activity.ts`, `athlete.ts`, `gear.ts`, `statistics.ts` — processamento de atividades e geração de estatísticas (chamados pelo webhook).
+### 💻 A. Restrições de Runtime e Ambiente
 
-Fluxos críticos & pontos de integração
+- **Next.js & TypeScript**: O projeto roda em Next.js (Node >= 16) com tipagem estática. Toda nova implementação deve manter o TypeScript estrito (`tsconfig.json`).
+- **Segredos e Variáveis de Ambiente**: Nunca versione tokens, senhas ou credenciais de APIs. Use exclusivamente o arquivo `.env.local` (não versionado) para carregar credenciais. Siga a estrutura de `.env.example`.
 
-- OAuth: fluxo completo em `src/pages/api/authorize.tsx` — troca `code` por tokens via `apiStravaOauthToken`, seta cookies e POSTa para `apiStravaAuth`/`save-tokens` (que persiste em Redis).
-- Gestão de tokens: `getAthleteAccessToken(athleteId)` lê `REDIS_KEYS.auth(athleteId)`, verifica expiração e chama `refreshStravaToken()` quando necessário.
-- Webhook: `src/pages/api/webhook.ts` valida `VERIFY_TOKEN`, processa eventos (`activity` / `athlete`), recupera token com `getAthleteAccessToken()`, cria cliente `Strava` e chama serviços de processamento/estatísticas. Falhas disparam `sendEmail()` onde aplicável.
-- Chamadas externas: todas as chamadas externas usam clientes em `src/services/api.ts` — altere ou adicione clientes lá para manter headers e timeouts consistentes.
+### 🛡️ B. Segurança de Dados e Privacidade
 
-Ambiente & segredos (o que configurar)
+- **Redis Server-Only**: O acesso direto ao Redis (`src/services/redis.ts`) é estritamente **server-side**. Nunca importe ou use conexões com o Redis em páginas frontend ou componentes client-side.
+- **Cookies de Sessão**: Cookies sensíveis (como `strava_code` e `strava_athleteId`) gerados em rotas de API devem ser configurados com `HttpOnly`, `Secure` (em produção) e política `SameSite=Strict` para mitigar CSRF.
+- **Privacidade do Ciclista (GDPR / LGPD)**: Eventos de deleção do atleta recebidos via webhook (`athlete` com `aspect_type: delete`) devem apagar imediatamente todas as chaves do atleta do Redis.
 
-- Variáveis necessárias: `CLIENT_ID`, `CLIENT_SECRET`, `GRANT_TYPE`, `VERIFY_TOKEN`, `NEXT_PUBLIC_CONTACT_EMAIL`, `RESEND_EMAIL_FROM`. Veja `Readme.md` para instruções locais.
-- Redis: em desenvolvimento o Redis é criado por `Redis.fromEnv()` — defina `UPSTASH_REDIS_REST_URL` e `UPSTASH_REDIS_REST_TOKEN` ou aponte para um Redis compatível.
-- Não codifique segredos em código; use `.env.local` e não comite essas variáveis.
+### ⚡ C. Concorrência e Resiliência
 
-Convenções e padrões do projeto
+- **Locks de Token Refresh**: Ao realizar o refresh do token de acesso do Strava, use sempre o lock distribuído baseado em Redis (`strava:lock:refresh:<athleteId>`) com `SET NX` e TTL adequado para evitar concorrência descontrolada (_cache stampede_). Siga o padrão de `src/services/strava-auth.ts`.
+- **Retries em APIs Externas**: Requisições externas para a API do Strava ou outras dependências devem usar políticas de retentativa exponencial (_exponential backoff_). Utilize a configuração pré-existente do `axios-retry` em `src/services/api.ts`.
+- **Idempotência de Webhooks**: Sempre deduplique eventos de webhook do Strava usando chaves temporárias de cache no Redis com TTL de 2 horas.
 
-- Cliente HTTP centralizado: estenda `src/services/api.ts` para novos endpoints externos — isso garante `timeout`, `Content-Type` e `X-Request-ID` padronizados.
-- Chaves Redis: use `REDIS_KEYS` do `config` para evitar colisões; `saveStravaAuth()` persiste tokens com `redis.setex` por 90 dias.
-- Tratamento de erros: rotas server-side geralmente usam `console.error` e notificam por email via `src/services/email.ts` em falhas inesperadas — siga esse padrão.
-- Código server-only: qualquer arquivo em `src/pages/api/*` ou que importe `src/services/redis.ts` é destinado ao runtime do servidor — não mova acesso a Redis para o cliente.
+### 📊 D. Observabilidade e Logs
 
-Exemplos práticos
+- **Logs Estruturados**: Nunca use `console.log` para depuração ou erro em produção. Utilize o logger estruturado **Pino** (`src/services/logger.ts`).
+- **Rastreabilidade (`X-Request-ID`)**: Garanta que o cabeçalho `X-Request-ID` seja propagado em logs secundários e chamadas assíncronas internas para facilitar o rastreamento em microsserviços e funções serverless.
 
-- Refresh de token: chame `getAthleteAccessToken(athleteId)` de `webhook` ou jobs para garantir `accessToken` válido (veja `src/services/strava-auth.ts`).
-- Novo cliente externo: registre no `src/services/api.ts` e importe onde necessário para herdar headers/timeouts.
+---
 
-Ao editar / adicionar código
+## 🚀 2. Receitas Práticas de Desenvolvimento (Skills)
 
-- Prefira patches pequenos e focados que preservem padrões existentes (clientes axios, `REDIS_KEYS`, fallback de email nas falhas).
-- Para mudanças em API, atualize a rota correspondente em `src/pages/api/*` e mantenha os segredos no servidor.
-- Valide localmente com:
+Qualquer alteração ou nova feature no projeto deve seguir os passo-a-passo consolidados abaixo para evitar regressões:
 
-```bash
-npm run dev
-# ou
-yarn dev
-```
+### 🔧 Skill 1: Cadastrar Novos Componentes de Manutenção (Equipments)
 
-Para testar webhooks, replique requisições POST do Strava e defina `VERIFY_TOKEN` corretamente.
+Para adicionar uma nova peça rastreável ao GearLife (ex: `helmet`, `shoes`, `freehub`):
 
-Arquivos para referência rápida
+1. **Configuração**: Adicione o ID e a legenda legível do componente no objeto `Equipments` em `src/services/equipment.ts`.
+   ```typescript
+   Helmet: { id: 'helmet', caption: 'capacete:', show: 'Capacete' }
+   ```
+2. **Lógica de Relação**: Adicione as regras de depuração ou exclusão mútua em `createStatistics` em `src/services/statistics.ts` caso a substituição da nova peça afete outras (ex: se o ciclista instala `tubeless`, as `tubes` antigas devem ser desativadas).
+3. **Validação**: Execute `yarn test` e certifique-se de que os testes unitários do fluxo de estatísticas continuam passando com a nova peça cadastrada.
 
-- `Readme.md`
-- OAuth: `src/pages/api/authorize.tsx`
-- Tokens: `src/services/strava-auth.ts`
-- Webhook: `src/pages/api/webhook.ts` e `src/services/activity.ts`
-- Clientes HTTP: `src/services/api.ts`
-- Redis: `src/services/redis.ts`
+### 📈 Skill 2: Criar Métricas de Telemetria Distribuída
 
-Se alguma seção ficou ambígua ou você quer exemplos concretos (payloads de webhook, snippets de teste, ou passos de CI), diga qual área deseja ampliar.
+Para adicionar um novo contador de eventos ou erros no painel Prometheus do projeto:
+
+1. **Definição**: Declare a métrica no arquivo `src/services/metrics.ts` usando o helper `createCounter`.
+   ```typescript
+   export const myNewEvent = createCounter(
+     'my_new_event_total',
+     'Descrição explicativa da métrica para o Prometheus',
+     ['label_name'], // Opcional: labels adicionais
+   );
+   ```
+2. **Incremento**: Chame o contador no código de produção no momento em que o evento ocorrer:
+   ```typescript
+   import { myNewEvent } from '../../services/metrics';
+   myNewEvent.inc({ label_name: 'sucesso' });
+   ```
+3. **Validação**: Suba o app e chame `/api/metrics` com a chave `X-Internal-Api-Key` para garantir que o contador está integrando ao Redis e saindo no formato Prometheus.
+
+### 🧪 Skill 3: Criar Testes Rápidos usando o Harness Next-API
+
+Para adicionar um novo teste de rota sem a necessidade de subir servidores de rede HTTP:
+
+1. **Criação**: No arquivo de teste (`tests/integration/*` ou `tests/unit/*`), importe a rota que deseja testar e os simuladores de API.
+   ```typescript
+   import handler from '../../src/pages/api/minha-rota';
+   import { createMockRequest, createMockResponse } from '../helpers/next-api';
+   ```
+2. **Montagem do Caso**: Monte os mocks de Request e Response com os headers e parâmetros desejados.
+   ```typescript
+   const req = createMockRequest({
+     method: 'POST',
+     headers: { 'x-request-id': 'teste-123' },
+     body: { dado: 'teste' },
+   });
+   const res = createMockResponse();
+   ```
+3. **Execução**: Execute o handler diretamente de forma assíncrona e valide os retornos:
+   ```typescript
+   await handler(req, res);
+   expect(res.statusCode).toBe(200);
+   expect(res.body).toEqual({ success: true });
+   ```
+
+### 📡 Skill 4: Executar e Simular Webhooks Localmente com o Dev-Harness
+
+Para testar alterações nos fluxos de dados sem precisar de túneis HTTPS ou contas reais do Strava:
+
+1. **Subir App**: Inicie a aplicação no localhost:
+   ```bash
+   yarn dev
+   ```
+2. **Autenticar Mock**: Crie um atleta de simulação temporário no Redis:
+   ```bash
+   node scripts/dev-harness.mjs auth-simulate 999888
+   ```
+3. **Disparar Webhook**: Simule a criação de uma atividade com asterisco no nome e ID do componente na nota privada:
+   ```bash
+   node scripts/dev-harness.mjs webhook-simulate 999888 777666 create "Treino de MTB *" "chain,lub"
+   ```
+4. **Verificar Resultados**: Inspecione o Redis para verificar se a quilometragem do atleta e do componente foi processada corretamente:
+   ```bash
+   node scripts/dev-harness.mjs redis-inspect 999888
+   ```
+
+---
+
+## 📝 3. Estrutura do Repositório (Referências)
+
+Antes de fazer alterações em módulos complexos, estude os arquivos de referência:
+
+- **Fluxo OAuth e Cookies**: `src/pages/api/authorize.tsx`
+- **Gestão e Locks de Token**: `src/services/strava-auth.ts`
+- **Cálculo de Desgaste e Estatísticas**: `src/services/statistics.ts`
+- **Recepção de Webhooks**: `src/pages/api/webhook.ts`
+- **Clientes e Configuração HTTP**: `src/services/api.ts`
+
+_Ao propor melhorias arquiteturais ou novos endpoints externos, garanta que todos os testes passem executando `yarn test` localmente antes de prosseguir com PRs ou commits._

--- a/scripts/dev-harness.mjs
+++ b/scripts/dev-harness.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+
+/**
+ * 🛠️ GearLife Local Development & Testing Harness CLI
+ * 
+ * Este script fornece uma ferramenta de linha de comando robusta para testar o GearLife
+ * localmente sem a necessidade de expor o localhost via túneis HTTPS (ngrok) ou depender
+ * de disparos reais da API do Strava. Ele interage com o Redis do projeto e simula requisições.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Redis } from '@upstash/redis';
+import crypto from 'node:crypto';
+
+// 1. Carregar variáveis do .env ou .env.local
+function loadEnv() {
+  const envFiles = ['.env.local', '.env'];
+  for (const file of envFiles) {
+    const path = resolve(process.cwd(), file);
+    if (existsSync(path)) {
+      const content = readFileSync(path, 'utf8');
+      content.split('\n').forEach((line) => {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) return;
+        const [key, ...valueParts] = trimmed.split('=');
+        const value = valueParts.join('=').trim();
+        if (key && value) {
+          // Remover aspas simples ou duplas se houver
+          process.env[key.trim()] = value.replace(/^['"]|['"]$/g, '');
+        }
+      });
+      break;
+    }
+  }
+}
+
+loadEnv();
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+const INTERNAL_API_TOKEN = process.env.INTERNAL_API_TOKEN;
+const WEBHOOK_SUBSCRIPTION_ID = Number(process.env.WEBHOOK_SUBSCRIPTION_ID || '123456');
+
+// Inicializar cliente do Redis
+let redis;
+try {
+  if (process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN) {
+    redis = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN,
+    });
+  }
+} catch (e) {
+  console.warn('⚠️ Alerta: Não foi possível conectar ao Upstash Redis localmente. Verifique suas credenciais.');
+}
+
+const REDIS_KEYS = {
+  auth: (athleteId) => `strava:auth:${athleteId}`,
+  activities: (athleteId) => `strava:activities:${athleteId}`,
+  statistics: (athleteId) => `strava:statistics:${athleteId}`,
+};
+
+const commands = {
+  help: () => {
+    console.log(`
+🚀 **GearLife Development Harness CLI** 🚴
+
+Uso:
+  node scripts/dev-harness.mjs <comando> [argumentos]
+
+Comandos Disponíveis:
+  
+  **1. Autenticação**
+    auth-simulate <athleteId>
+      Simula e injeta um cadastro de autenticação OAuth diretamente no Redis para um determinado atleta.
+      Isso habilita o webhook a aceitar eventos desse atleta sem passar pelo fluxo real do Strava.
+  
+  **2. Simulação de Webhooks**
+    webhook-simulate <athleteId> <activityId> <create|update|delete> [activityName] [privateNote]
+      Dispara um evento de webhook mockado simulando a API do Strava para a aplicação local.
+      - Se aspectType for 'create' ou 'update', e activityName contiver '*', a rota local do Next.js
+        irá processar a atividade e atualizar o cache do Redis.
+  
+  **3. Inspeção de Dados**
+    redis-inspect <athleteId>
+      Lê diretamente do Redis o estado atualizado do atleta (dados de login, atividades cacheadas e estatísticas).
+  
+  **4. Observabilidade**
+    metrics-fetch
+      Consome o endpoint de métricas (/api/metrics) usando a chave de API interna e exibe os contadores Prometheus em tempo real.
+    `);
+  },
+
+  'auth-simulate': async (athleteIdStr) => {
+    if (!redis) throw new Error('Cliente do Redis não configurado no .env');
+    const athleteId = Number(athleteIdStr);
+    if (!athleteId || isNaN(athleteId)) {
+      console.error('❌ Por favor, informe um athleteId numérico válido.');
+      return;
+    }
+
+    const mockAuth = {
+      refreshToken: 'mock_refresh_token_123456',
+      accessToken: 'mock_access_token_123456',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600 * 6, // Válido por 6 horas
+      lastUpdated: Math.floor(Date.now() / 1000),
+      athleteInfo: {
+        id: athleteId,
+        username: 'atleta_teste',
+        firstname: 'Ciclista',
+        lastname: 'Simulado',
+        city: 'São Paulo',
+        state: 'SP',
+        country: 'Brazil',
+        sex: 'M',
+        premium: false,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        badge_type_id: 0,
+        weight: 75.5,
+        profile_medium: 'https://images.peer.strava.com/placeholder.png',
+        profile: 'https://images.peer.strava.com/placeholder.png',
+        friend: null,
+        follower: null,
+      },
+    };
+
+    const key = REDIS_KEYS.auth(athleteId);
+    await redis.setex(key, 90 * 24 * 3600, JSON.stringify(mockAuth));
+    console.log(`✅ Auth simulação injetada no Redis sob a chave: ${key}`);
+    console.log(JSON.stringify(mockAuth, null, 2));
+  },
+
+  'webhook-simulate': async (athleteIdStr, activityIdStr, aspectType, activityName = 'Pedal com troca de corrente *', privateNote = 'chain,lub') => {
+    const athleteId = Number(athleteIdStr);
+    const activityId = Number(activityIdStr);
+
+    if (!athleteId || !activityId || !aspectType) {
+      console.error('❌ Parâmetros inválidos. Uso: node scripts/dev-harness.mjs webhook-simulate <athleteId> <activityId> <create|update|delete> [activityName] [privateNote]');
+      return;
+    }
+
+    const payload = {
+      object_type: 'activity',
+      object_id: activityId,
+      aspect_type: aspectType,
+      updates: aspectType === 'update' ? { title: activityName } : {},
+      owner_id: athleteId,
+      subscription_id: WEBHOOK_SUBSCRIPTION_ID,
+      event_time: Math.floor(Date.now() / 1000),
+    };
+
+    console.log(`📡 Enviando webhook mockado para ${APP_URL}/api/webhook...`);
+    console.log('Payload:', JSON.stringify(payload, null, 2));
+
+    try {
+      const response = await fetch(`${APP_URL}/api/webhook`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Request-Id': `harness-${crypto.randomUUID().slice(0, 8)}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const text = await response.text();
+      console.log(`\nStatus HTTP de Resposta: ${response.status}`);
+      try {
+        const json = JSON.parse(text);
+        console.log('Dados de Resposta:', JSON.stringify(json, null, 2));
+      } catch (_) {
+        console.log('Resposta Bruta:', text);
+      }
+    } catch (e) {
+      console.error('❌ Falha ao conectar ao servidor local. Verifique se o app Next.js está rodando (npm run dev).', e.message);
+    }
+  },
+
+  'redis-inspect': async (athleteIdStr) => {
+    if (!redis) throw new Error('Cliente do Redis não configurado no .env');
+    const athleteId = Number(athleteIdStr);
+    if (!athleteId || isNaN(athleteId)) {
+      console.error('❌ Por favor, informe um athleteId numérico válido.');
+      return;
+    }
+
+    console.log(`🔍 Inspecionando dados no Redis para o Atleta #${athleteId}...\n`);
+
+    const auth = await redis.get(REDIS_KEYS.auth(athleteId));
+    const activities = await redis.get(REDIS_KEYS.activities(athleteId));
+    const stats = await redis.get(REDIS_KEYS.statistics(athleteId));
+
+    console.log('--- 🔑 AUTH DATA ---');
+    console.log(auth ? JSON.stringify(auth, null, 2) : 'Nenhum dado de autenticação encontrado.');
+
+    console.log('\n--- 🚴 ACTIVITES ---');
+    console.log(activities ? `Encontradas ${activities.activities?.length || 0} atividades. Última atualização: ${new Date(activities.lastUpdated * 1000).toLocaleString()}` : 'Nenhuma atividade armazenada.');
+
+    console.log('\n--- 📊 STATISTICS & GEAR ---');
+    console.log(stats ? JSON.stringify(stats, null, 2) : 'Nenhuma estatística processada.');
+  },
+
+  'metrics-fetch': async () => {
+    if (!INTERNAL_API_TOKEN) {
+      console.error('❌ INTERNAL_API_TOKEN não está definido no .env do seu projeto.');
+      return;
+    }
+
+    console.log(`📡 Buscando métricas do servidor em ${APP_URL}/api/metrics...`);
+    try {
+      const response = await fetch(`${APP_URL}/api/metrics`, {
+        method: 'GET',
+        headers: {
+          'X-Internal-Api-Key': INTERNAL_API_TOKEN,
+        },
+      });
+
+      const text = await response.text();
+      console.log(`\nStatus HTTP de Resposta: ${response.status}`);
+      if (response.ok) {
+        console.log('--- 📈 PROMETHEUS METRICS ---');
+        console.log(text);
+      } else {
+        console.error('Erro:', text);
+      }
+    } catch (e) {
+      console.error('❌ Falha ao buscar métricas locais. O servidor local está online?', e.message);
+    }
+  },
+};
+
+async function main() {
+  const [cmd, ...args] = process.argv.slice(2);
+  if (!cmd || !commands[cmd]) {
+    commands.help();
+    return;
+  }
+
+  try {
+    await commands[cmd](...args);
+  } catch (error) {
+    console.error(`❌ Erro durante a execução do comando "${cmd}":`, error.message);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds a lightweight local development harness CLI and updates the repo AI/agent guidelines.

## Technical details

- Adds `scripts/dev-harness.mjs` (Node CLI) to:
  - Inject a mock Strava OAuth auth payload into Redis (`auth-simulate`).
  - POST a webhook event to the local Next.js endpoint (`webhook-simulate`).
  - Inspect athlete-related Redis keys (`redis-inspect`).
  - Fetch Prometheus metrics from `/api/metrics` using `X-Internal-Api-Key` (`metrics-fetch`).
- Updates `.github/copilot-instructions.md` with stricter rules (server-only Redis usage, cookies/security notes, observability notes) and a short recipe for using the harness.

## Notes

- Requires `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` in `.env.local` (and `INTERNAL_API_TOKEN` for `metrics-fetch`).
- Run examples:
  - `node scripts/dev-harness.mjs auth-simulate 999888`
  - `node scripts/dev-harness.mjs webhook-simulate 999888 777666 create "Treino *" "chain,lub"`
  - `node scripts/dev-harness.mjs redis-inspect 999888`
  - `node scripts/dev-harness.mjs metrics-fetch`
