### PR TITLE
feat(home): improve mobile hero

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -39,8 +39,33 @@ function HomeContent() {
           <div className={styles.homeText}>
             <ErroMsg />
             <h1>GearLife</h1>
-            <h2>Monitor your gear.</h2>
-            <h2>Ride smarter.</h2>
+            <h2 className={styles.tagline}>Monitor your gear. Ride smarter.</h2>
+            <p className={styles.subtitle}>
+              Conecte sua conta Strava para acompanhar seus equipamentos.
+            </p>
+
+            <div
+              className={styles.ctaRow}
+              role='group'
+              aria-label='Ações principais'
+            >
+              <Link
+                href='/api/oauth/start'
+                prefetch={false}
+                className={styles.ctaPrimary}
+              >
+                Entrar com Strava
+              </Link>
+              <Link href='/como-funciona' className={styles.ctaSecondary}>
+                Como funciona
+              </Link>
+            </div>
+
+            <ul className={styles.featureList} aria-label='Destaques'>
+              <li>Estatísticas por bike e componente</li>
+              <li>Atualização automática</li>
+              <li>Privacidade: leitura apenas do que precisa</li>
+            </ul>
           </div>
 
           <div className={styles.versionMark}>

--- a/src/styles/pages/Home.module.css
+++ b/src/styles/pages/Home.module.css
@@ -11,15 +11,18 @@
 .homeSection {
   position: relative;
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding-bottom: 7.5rem;
 }
 
 .homeText {
-  min-height: 60vh;
-
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 0.6rem;
 
   font-family: var(--font-inter), var(--font-jetbrains), sans-serif;
 }
@@ -59,9 +62,9 @@
 }
 
 .homeText h1 {
-  font-size: 7.8rem;
+  font-size: clamp(4.4rem, 10.5vw, 7.8rem);
   font-weight: 700;
-  line-height: 8.8rem;
+  line-height: 1.05;
   letter-spacing: -0.3rem;
   text-align: center;
 
@@ -77,10 +80,10 @@
 }
 
 .homeText h2 {
-  font-size: 1.8rem;
+  font-size: clamp(1.45rem, 5.6vw, 1.9rem);
   font-weight: 400;
-  line-height: 2.8rem;
-  letter-spacing: -0.1rem;
+  line-height: 1.25;
+  letter-spacing: -0.06rem;
   text-align: center;
 
   -webkit-background-clip: text;
@@ -92,6 +95,92 @@
     var(--start-gradient-color),
     var(--end-gradient-color)
   );
+}
+
+.tagline {
+  margin-top: 0.2rem;
+  max-width: 28rem;
+}
+
+.subtitle {
+  margin: 0.1rem 0 0.2rem;
+  max-width: 34rem;
+  text-align: center;
+  color: var(--gray-notes);
+  font-size: 1.05rem;
+  line-height: 1.55;
+}
+
+.ctaRow {
+  margin-top: 0.6rem;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.ctaPrimary,
+.ctaSecondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 2.8rem;
+  padding: 0 1.1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.ctaPrimary {
+  color: #0b1020;
+  background-image: linear-gradient(
+    90deg,
+    var(--start-gradient-color),
+    var(--end-gradient-color)
+  );
+}
+
+.ctaPrimary:hover {
+  filter: brightness(0.98);
+}
+
+.ctaPrimary:focus-visible,
+.ctaSecondary:focus-visible {
+  outline: 2px solid var(--light-blue);
+  outline-offset: 2px;
+}
+
+.ctaSecondary {
+  color: var(--dark-gray);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.ctaSecondary:hover {
+  border-color: rgba(255, 255, 255, 0.3);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.featureList {
+  margin: 0.8rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  max-width: 42rem;
+}
+
+.featureList li {
+  font-size: 0.95rem;
+  color: var(--gray-notes);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background-color: rgba(255, 255, 255, 0.03);
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
 }
 
 .homeText span {
@@ -129,20 +218,17 @@
   .container {
     padding-top: 4.8rem;
   }
-  .homeText {
-    min-height: 48vh;
-  }
 
   .homeText h1 {
-    font-size: 6.2rem;
-    line-height: 6.6rem;
     letter-spacing: -0.2rem;
   }
 
   .homeText h2 {
-    font-size: 1.6rem;
-    line-height: 2.2rem;
     letter-spacing: 0rem;
+  }
+
+  .subtitle {
+    font-size: 1rem;
   }
 
   .versionMark {
@@ -164,20 +250,9 @@
   .container {
     padding-top: 5.2rem;
   }
-  .homeText {
-    min-height: 42vh;
-  }
 
-  .homeText h1 {
-    font-size: 5rem;
-    line-height: 5.4rem;
-    letter-spacing: -0.2rem;
-  }
-
-  .homeText h2 {
-    font-size: 1.35rem;
-    line-height: 1.9rem;
-    letter-spacing: 0rem;
+  .ctaRow {
+    gap: 0.6rem;
   }
 
   .marketingNav a {
@@ -189,19 +264,22 @@
   .container {
     padding-top: 5.6rem;
   }
-  .homeText {
-    min-height: 38vh;
+
+  .subtitle {
+    font-size: 0.98rem;
   }
 
-  .homeText h1 {
-    font-size: 4.4rem;
-    line-height: 4.8rem;
-    letter-spacing: -0.1rem;
+  .featureList {
+    margin-top: 0.7rem;
+    gap: 0.45rem;
   }
 
-  .homeText h2 {
-    font-size: 1.15rem;
-    line-height: 1.6rem;
-    letter-spacing: 0rem;
+  .featureList li {
+    font-size: 0.92rem;
+  }
+
+  .ctaPrimary,
+  .ctaSecondary {
+    height: 2.7rem;
   }
 }


### PR DESCRIPTION
## Context
On iPhone 15 the home hero felt small and the page looked visually empty.

## What changed
- Improves hero readability with fluid typography (`clamp`) for the title and tagline.
- Replaces the 2-line tagline with a single stronger line.
- Adds a short product subtitle to reduce the “empty” feel.
- Adds primary/secondary CTAs (login + how-it-works) to drive action.
- Adds small benefit chips for extra density without clutter.
- Centers the hero vertically while reserving space for the bottom version/marketing block.

## Files
- `src/pages/index.tsx`
- `src/styles/pages/Home.module.css`

## Validation
- `yarn test tests/unit/pages/home-page.test.tsx`