### PR TITLE
chore(mcp): document GitHub MCP usage in rules

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -103,10 +103,35 @@ Para testar alterações nos fluxos de dados sem precisar de túneis HTTPS ou co
 ## 📝 3. Estrutura do Repositório (Referências)
 
 Antes de fazer alterações em módulos complexos, estude os arquivos de referência:
-* **Fluxo OAuth e Cookies**: [authorize.tsx](file:///home/rbalbi/Documentos/vscode-workspace/strava-next/src/pages/api/authorize.tsx)
-* **Gestão e Locks de Token**: [strava-auth.ts](file:///home/rbalbi/Documentos/vscode-workspace/strava-next/src/services/strava-auth.ts)
-* **Cálculo de Desgaste e Estatísticas**: [statistics.ts](file:///home/rbalbi/Documentos/vscode-workspace/strava-next/src/services/statistics.ts)
-* **Recepção de Webhooks**: [webhook.ts](file:///home/rbalbi/Documentos/vscode-workspace/strava-next/src/pages/api/webhook.ts)
-* **Clientes e Configuração HTTP**: [api.ts](file:///home/rbalbi/Documentos/vscode-workspace/strava-next/src/services/api.ts)
+* **Fluxo OAuth e Cookies**: `src/pages/api/authorize.tsx`
+* **Gestão e Locks de Token**: `src/services/strava-auth.ts`
+* **Cálculo de Desgaste e Estatísticas**: `src/services/statistics.ts`
+* **Recepção de Webhooks**: `src/pages/api/webhook.ts`
+* **Clientes e Configuração HTTP**: `src/services/api.ts`
 
 *Ao propor melhorias arquiteturais ou novos endpoints externos, garanta que todos os testes passem executando `yarn test` localmente antes de prosseguir com PRs ou commits.*
+
+---
+
+## 🧩 4. MCPs Instalados (Como Usar)
+
+Estas regras definem quando e como usar os MCPs (Model Context Protocol) disponíveis no ambiente do agente.
+
+### 🐙 A. GitHub (MCP/Connector)
+Use o MCP do GitHub quando precisar de contexto **remoto** (PRs, issues, diffs, reviews, status de CI) em vez de “adivinhar” com base em memória.
+
+Regras:
+* **Prefira o MCP para PR/Issue**: Para ler descrições, comentários, patches, checks e threads de review, utilize o conector do GitHub ao invés de pedir para o usuário copiar/colar conteúdo.
+* **Mudanças em PRs**: Ao endereçar feedback de review, busque **threads não resolvidas** e comente/atualize de forma objetiva, evitando alterações não relacionadas.
+* **CI e logs**: Para falhas de workflow, obtenha logs pelo GitHub (runs/jobs) antes de alterar código; corrija a causa raiz com mudanças mínimas.
+* **Sem segredos**: Nunca copie tokens/segredos do GitHub Actions/Secrets para o repositório ou logs locais.
+
+Exemplos do que buscar via GitHub MCP:
+* Arquivos alterados e patch de um PR (para revisão e correção pontual).
+* Comentários inline de review (para responder exatamente onde foi pedido).
+* Status de checks e logs (para identificar o erro real e reproduzir localmente).
+
+### 🧰 B. Descoberta de Ferramentas MCP
+Quando não souber qual ferramenta MCP usar (ex.: qual ação existe para “listar issues”, “buscar PR”, “baixar artifact”), faça **descoberta de ferramentas** primeiro e só então execute a ação:
+* Pesquise ferramentas disponíveis (tool discovery) com termos como `github pr`, `issue comments`, `workflow logs`, `artifact`.
+* Se a ferramenta ideal existir, use-a; se não existir, caia para fluxo local (clone/arquivos) apenas quando fizer sentido.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -123,3 +123,15 @@ Antes de fazer alterações em módulos complexos, estude os arquivos de referê
 - **Clientes e Configuração HTTP**: `src/services/api.ts`
 
 _Ao propor melhorias arquiteturais ou novos endpoints externos, garanta que todos os testes passem executando `yarn test` localmente antes de prosseguir com PRs ou commits._
+
+---
+
+## 🧩 4. MCPs Instalados (Como Usar)
+
+### 🐙 GitHub (MCP/Connector)
+- Use o MCP do GitHub para buscar contexto remoto (PRs, issues, diffs, reviews e status de CI) antes de propor mudanças.
+- Ao corrigir feedback de PR, priorize threads de review não resolvidas e aplique patches mínimos e focados.
+- Nunca copie segredos do GitHub (Actions/Secrets) para o código ou logs.
+
+### 🧰 Descoberta de Ferramentas
+- Se não souber qual ação do MCP usar, faça descoberta de ferramentas (ex.: `github pr`, `workflow logs`, `issue comments`) e só então execute a ação adequada.

--- a/.github/instructions/rules.instructions.md
+++ b/.github/instructions/rules.instructions.md
@@ -68,8 +68,11 @@ Quick reference files
 - HTTP clients: `src/services/api.ts`
 - Redis: `src/services/redis.ts`
 
+MCPs installed (how to use)
+
+- GitHub MCP/Connector: use it to fetch PR/issue context (diffs, review threads, comments, CI status/logs) before changing code.
+- Tool discovery: if unsure which MCP action exists, search/discover tools first (e.g. `workflow logs`, `pr patch`, `issue comments`) and then call the most specific action.
+- Secrets: never paste GitHub Actions/Secrets into code, PR comments, or logs.
+
 If any section is ambiguous or you want concrete examples (webhook payloads, test snippets, or CI steps), specify which area to expand.
-
-```
-
-```
+````


### PR DESCRIPTION
## O que mudou

- Documenta o uso do **GitHub MCP/Connector** nos arquivos de regras/instructions do repositório.
- Inclui orientação de **tool discovery** para quando não houver certeza de qual ação MCP utilizar.

## Motivação

Evitar que o agente “adivinhe” contexto remoto (PRs/issues/diffs/reviews/CI) e padronizar quando buscar esse contexto via MCP antes de propor mudanças.

## Detalhes técnicos

- Atualiza `.cursorrules` com seção **“MCPs Instalados (Como Usar)”** (GitHub MCP + descoberta de ferramentas).
- Atualiza `.github/copilot-instructions.md` com instruções equivalentes para assistentes.
- Atualiza `.github/instructions/rules.instructions.md` com seção de MCPs e corrige o fechamento do bloco ````instructions.

## Escopo

Apenas documentação/instruções — sem mudanças de runtime, código de aplicação ou dependências.